### PR TITLE
add pry gem dependency

### DIFF
--- a/presigner.gemspec
+++ b/presigner.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "thor"
   spec.add_dependency "aws-sdk-v1"
+  spec.add_dependency "pry"
 end


### PR DESCRIPTION
pry gemを入れないとエラーになったので、依存定義に追加する必要があると思います。

```
$ presigner
/Users/ryuta/.rbenv/versions/2.1.2/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:126:in `require': cannot load such file -- pry (LoadError)
    from /Users/ryuta/.rbenv/versions/2.1.2/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:126:in `require'
    from /Users/ryuta/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/presigner-0.0.2/lib/presigner.rb:4:in `<top (required)>'
    from /Users/ryuta/.rbenv/versions/2.1.2/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:73:in `require'
    from /Users/ryuta/.rbenv/versions/2.1.2/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:73:in `require'
    from /Users/ryuta/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/presigner-0.0.2/bin/presigner:3:in `<top (required)>'
    from /Users/ryuta/.rbenv/versions/2.1.2/bin/presigner:23:in `load'
    from /Users/ryuta/.rbenv/versions/2.1.2/bin/presigner:23:in `<main>'
$ gem install pry --no-ri --no-rdoc
Fetching: coderay-1.1.0.gem (100%)
Successfully installed coderay-1.1.0
Fetching: slop-3.6.0.gem (100%)
Successfully installed slop-3.6.0
Fetching: method_source-0.8.2.gem (100%)
Successfully installed method_source-0.8.2
Fetching: pry-0.10.1.gem (100%)
Successfully installed pry-0.10.1
4 gems installed
$ presigner
WARN: Unresolved specs during Gem::Specification.reset:
      thor (>= 0)
WARN: Clearing out unresolved specs.
Please report a bug if this causes problems.
Commands:
  presigner generate --bucket=BUCKET --key=KEY  # generate S3 presigned URL
  presigner help [COMMAND]                      # Describe available commands or one specific command
$
```
