### PR TITLE
simplify assignments of optional arguments and default values

### DIFF
--- a/lib/presigner.rb
+++ b/lib/presigner.rb
@@ -9,8 +9,8 @@ class Presigner
   def initialize(options)
     @bucket = options[:bucket]
     @key = options[:key]
-    @duration = options[:duration].nil? ? DEFAULT_DURATION : options[:duration].to_i
-    @region = options[:region].nil? ? "us-east-1" : options[:region]
+    @duration = options[:duration] || DEFAULT_DURATION
+    @region = options[:region] || "us-east-1"
     @base = Time.now.to_i
   end
 

--- a/test/test_presigner.rb
+++ b/test/test_presigner.rb
@@ -30,4 +30,23 @@ class PresignerTest < Test::Unit::TestCase
     assert_equal(actual, Presigner::DEFAULT_DURATION)
   end
 
+  test "check Presigner.new without optional arguments" do
+    presigner = Presigner.new(bucket: 'foobucket',
+                              key: 'barkey')
+    ## maybe < 2 sec.
+    assert_true(presigner.base < Time.now.to_i + 2 && presigner.base > Time.now.to_i - 1)
+    assert_equal(Presigner::DEFAULT_DURATION, presigner.duration)
+    assert_equal("us-east-1", presigner.region)
+  end
+
+  test "check Presigner.new with optional arguments" do
+    presigner = Presigner.new(bucket: 'foobucket',
+                              key: 'barkey',
+                              duration: 123,
+                              region: 'ap-northeast-1',
+                              )
+    assert_equal(123, presigner.duration)
+    assert_equal("ap-northeast-1", presigner.region)
+  end
+
 end


### PR DESCRIPTION
`foo = bar.nil? ? "buz" : bar` is almost same as `foo = bar || "buz"` in Ruby.
(if you don't want to assign `false` into `foo`)

I also add some tests for optional aruguments.  I hope this PR doesn't break the gem.
